### PR TITLE
Query form customisation repair

### DIFF
--- a/app/assets/stylesheets/katalyst/tables/_query.scss
+++ b/app/assets/stylesheets/katalyst/tables/_query.scss
@@ -2,6 +2,7 @@
   position: relative;
 
   .query-input {
+    position: relative;
     display: grid;
     grid-template-areas: "input button";
     grid-template-columns: 1fr auto;

--- a/app/components/katalyst/tables/query_component.html.erb
+++ b/app/components/katalyst/tables/query_component.html.erb
@@ -1,8 +1,11 @@
-<% if content? %>
-    <%= content %>
-<% else %>
-  <%= form do |form| %>
-    <%= render query_input(form:) %>
+<%= form_with(**html_attributes, **@form_options) do |form| %>
+  <% with_query_input(form:) %>
+
+  <%= sort_input(form:) %>
+  <% if @form_block %>
+    <%= capture(form, &@form_block) %>
+  <% else %>
+    <%= query_input %>
     <%= modal %>
   <% end %>
 <% end %>

--- a/spec/components/katalyst/tables/query_component_spec.rb
+++ b/spec/components/katalyst/tables/query_component_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe Katalyst::Tables::QueryComponent do
   it "renders with custom content" do
     create_collection
     expect((render_inline(component) do
-      component.form(class: "custom") do |form|
-        component.concat(form.hidden_field(:example))
+      component.with_form(class: "custom") do |form|
+        component.helpers.concat(form.text_field(:example))
       end
     end).at_css("form.custom > input[name=example]")).to match_html(<<~HTML)
-      <input autocomplete="off" type="hidden" name="example" id="example">
+      <input type="text" name="example" id="example">
     HTML
   end
 


### PR DESCRIPTION
Previous approach didn't work with anything more than a single input. Test was not testing the right thing as it rendered via the view component instead of via the template.

Note, this requires the view_component capture compatibility patch:

```
config.view_component.capture_compatibility_patch_enabled = true
```