### PR TITLE
Orderable: Remove form from visible flow

### DIFF
--- a/app/components/katalyst/tables/orderable/form_component.rb
+++ b/app/components/katalyst/tables/orderable/form_component.rb
@@ -21,9 +21,15 @@ module Katalyst
         end
 
         def call
-          form_with(id:, url:, method: :patch, data: {
+          form_with(id:,
+                    url:,
+                    method: :patch,
+                    data:   {
                       controller:                       FORM_CONTROLLER,
                       "#{FORM_CONTROLLER}-scope-value": @scope,
+                    },
+                    html:   {
+                      hidden: "",
                     }) do |form|
             form.button(hidden: "")
           end

--- a/spec/components/katalyst/tables/orderable_spec.rb
+++ b/spec/components/katalyst/tables/orderable_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Katalyst::Tables::Orderable do
       <form id="#{form_id}"
             data-controller="tables--orderable--form"
             data-tables--orderable--form-scope-value="order[faqs]"
-            action="/faqs/order" accept-charset="UTF-8" method="post">
+            action="/faqs/order" accept-charset="UTF-8" method="post" hidden="hidden">
         <input type="hidden" name="_method" value="patch">
         <button name="button" type="submit" hidden="hidden">Save </button>
       </form>


### PR DESCRIPTION
Matching selectable form and removing from visible flow by adding `hidden`.
Adding support for users to add html attributes to the form